### PR TITLE
Task-6 Add TimeUnit util class for milliseconds formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ The static methods in utility classes are used for performing common routines in
 - Option to show/hide units for zero values.
 - Two formatting options: Full and Short.
 
+## Future enhancements
+
+- Create a pipeline which build and publish the artifacts to rabobank's internal repository of artifacts.
+- Add a new stage  in pipeline which run the unit tests and make sure the code meets the mandatory code coverage.
+- Add a new stage in pipeline which integrates with SonarQuobe for assuring the code quality.
+
 ## Getting Started
 
 ### Prerequisites
@@ -32,5 +38,12 @@ Add the following dependency to your Maven project:
         <version>{version}</version>
     </dependency>
 </dependencies>
+
+## Future enhancements
+
+- Create a pipeline which build and publish the artifacts to rabobank's internal repository of artifacts.
+- Add a new stage  in pipeline which run the unit tests and make sure the code meets the mandatory code coverage.
+- Add a new stage in pipeline which integrates with SonarQuobe for assuring the code quality.
+
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.rabobank.digital.util</groupId>
     <artifactId>Utility</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/src/main/java/com/rabobank/digital/util/time/TimeUtil.java
+++ b/src/main/java/com/rabobank/digital/util/time/TimeUtil.java
@@ -1,8 +1,11 @@
 package com.rabobank.digital.util.time;
 
+import java.sql.Time;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 public final class TimeUtil {
+
     private TimeUtil() {
     }
 
@@ -40,22 +43,25 @@ public final class TimeUtil {
      * Formats the given duration in milliseconds to seconds.
      *
      * @param milliseconds The duration in milliseconds.
+     * @param timeFormat The desired format for the output.
      * @return The formatted time duration in seconds.
      */
     public static String formatMillisecondsToSeconds(long milliseconds,Format timeFormat) {
         String unitSeconds=timeFormat==Format.s ? "s" : " seconds";
-        long seconds = milliseconds / 1000;
+        long seconds = TimeUnit.MILLISECONDS.toSeconds(milliseconds);
         return seconds + unitSeconds;
     }
     /**
      * Formats the given duration in milliseconds to minutes and seconds.
      *
      * @param milliseconds The duration in milliseconds.
+     * @param timeFormat The desired format for the output.
      * @return The formatted time duration in minutes and seconds.
      */
     public static String formatMillisecondsToMinutesSeconds(long milliseconds,Format timeFormat) {
-        long minutes = (milliseconds / 1000) / 60;
-        long seconds = (milliseconds / 1000) % 60;
+        long minutes = TimeUnit.MILLISECONDS.toMinutes(milliseconds);
+        long seconds = TimeUnit.MILLISECONDS.toSeconds(milliseconds);
+        seconds = seconds % 60;
 
         String unitSeconds=timeFormat==Format.m_s ? "s " : " seconds";
         String unitMinutes=timeFormat==Format.m_s ? "m " : " minutes ";
@@ -76,12 +82,13 @@ public final class TimeUtil {
      * Formats the given duration in milliseconds to hours, minutes, and seconds.
      *
      * @param milliseconds The duration in milliseconds.
+     * @param timeFormat The desired format for the output.
      * @return The formatted time duration in hours, minutes, and seconds.
      */
     public static String formatMillisecondsToHoursMinutesSeconds(long milliseconds,Format timeFormat) {
-        long hours = (milliseconds / 1000) / 3600;
-        long minutes = ((milliseconds / 1000) % 3600) / 60;
-        long seconds = (milliseconds / 1000) % 60;
+        long hours = TimeUnit.MILLISECONDS.toHours(milliseconds);
+        long minutes = TimeUnit.MILLISECONDS.toMinutes(milliseconds) % 60;
+        long seconds = TimeUnit.MILLISECONDS.toSeconds(milliseconds) % 60;
 
         String unitSeconds=timeFormat==Format.h_m_s ? "s " : " seconds ";
         String unitMinutes=timeFormat==Format.h_m_s ? "m " : " minutes ";

--- a/src/test/java/com/rabobank/digital/util/time/TimeUtilTest.java
+++ b/src/test/java/com/rabobank/digital/util/time/TimeUtilTest.java
@@ -37,7 +37,7 @@ public class TimeUtilTest {
         assertEquals("0s", TimeUtil.format(100,Unit.MILLISECONDS,Format.m_s));
     }
     @Test
-    public void testFormatHoursToHoursMinutesSeconds() {
+    public void testFormatMillisecondsToHoursMinutesSeconds() {
         assertEquals("3 minutes 34 seconds", TimeUtil.format(214000,Unit.MILLISECONDS,Format.hours_minutes_seconds));
         assertEquals("5 hours 3 minutes 14 seconds", TimeUtil.format(18194000,Unit.MILLISECONDS,Format.hours_minutes_seconds));
         assertEquals("4 seconds", TimeUtil.format(4000,Unit.MILLISECONDS,Format.hours_minutes_seconds));


### PR DESCRIPTION
Task-6 replace the existing logic for milliseconds to different time units with Java's TimeUnit util class.

Its wise to re use the existing Java functionality since its already part of JVM.

1. Added new version in pom.xml.
2. Modify the existing format functions to accomodate TimeUnit util class.
3. Made some changes in Readme.md about future enhancements.
4. Ammended a typo error which noticed in Test class.